### PR TITLE
Show more helpful profiling formation

### DIFF
--- a/blocks.py
+++ b/blocks.py
@@ -4,24 +4,42 @@ import parser
 nextBlockId = 0
 
 class Block(object):
-	def __init__(self):
+	def __init__(self, line, label=None):
 		global nextBlockId
 		self.blockId = nextBlockId
 		nextBlockId += 1
 		self.instructions = []
+		self.line = line
+		self.label = label
 		self.endJump = None
 		self.conditionalDestination = None
 		self.defaultDestination = None
 
+	def __repr__(self):
+		if self.label:
+		        return 'Block %s @%s' % (self.label, self.line)
+		return 'Block @%s' % self.line
+
+	def instructionCount(self):
+		if self.endJump:
+		    return len(self.instructions) + 1
+		return len(self.instructions)
+	
+
 def blocker(s):
 	program, labels, metadata = parser.parse(s)
-	start = Block()
+	start = Block(0)
 	current = start
-	labelToBlocks = {idx: Block() for idx in set(labels.values())}
+	lineToLabel = {line: label for label, line in labels.iteritems()}
+	labelToBlocks = {}
+	for label, line in labels.iteritems():
+	    labelToBlocks[line] = Block(line, label)
 	print labelToBlocks
+	lastLabelLine = 0
 	for p, instr in enumerate(program):
 		print "At %d: %s" % (p, instr)
 		if p in labelToBlocks and labelToBlocks[p] != current:
+			lastLabelLine = p
 			assert current.defaultDestination is None
 			current.defaultDestination = labelToBlocks[p]
 			current = current.defaultDestination
@@ -33,11 +51,14 @@ def blocker(s):
 				if p+1 in labelToBlocks:
 					current.defaultDestination = labelToBlocks[p+1]
 				else:
-					current.defaultDestination = Block()
+					current.defaultDestination = Block(
+						p+1,
+						'%s+%s' % (lineToLabel[lastLabelLine],
+							   p - lastLabelLine))
 				current = current.defaultDestination
 			else:
 				current.defaultDestination = targetBlock
-				current = Block()  # empty block that'll be garbage collected
+				current = Block(p)  # empty block that'll be garbage collected
 		else:
 			current.instructions.append(instr)
 	return start, metadata

--- a/runner.py
+++ b/runner.py
@@ -2,6 +2,7 @@ import collections
 
 import instructions
 import parser
+import pprint
 import blocks
 import levelloader
 
@@ -82,4 +83,9 @@ def run(block, state):
 if __name__ == '__main__':
 	import loader
 	start, metadata = blocks.blocker(loader.loadProgram())
-	print run(start, State.fromLevel(loader.pickLevel()))
+	blockUses = run(start, State.fromLevel(loader.pickLevel()))
+	perf = list(sorted([ (block, uses, uses * block.instructionCount())
+		for block, uses in blockUses.iteritems()],
+		key=lambda x: x[2]))
+	pprint.pprint(perf)
+	print(sum(x[2] for x in perf))


### PR DESCRIPTION
Example

```
[(Block bump15 @43, 0, 0),
 (Block bump16 @62, 0, 0),
 (Block writeboth+16 @61, 0, 0),
 (Block sort5skip6+3 @153, 0, 0),
 (Block simplywritefirst @56, 0, 0),
 (Block sort5skip4+2 @134, 0, 0),
 (Block output15+4 @69, 1, 1),
 (Block sort5skip8+3 @173, 2, 2),
 (Block writeboth @44, 1, 2),
 (Block onlysecondrow @188, 2, 2),
 (Block zeroloop+6 @42, 2, 2),
 (Block simplywritesecondbumpzero @174, 2, 2),
 (Block check16 @46, 1, 2),
 (Block writesingle @185, 1, 3),
 (Block sort5skip3 @121, 3, 6),
 (Block sort5skip7+3 @163, 1, 6),
 (Block sort5skip8+1 @171, 3, 6),
 (Block sort5skip5+2 @143, 1, 6),
 (Block sort5skip6+1 @151, 3, 6),
 (Block sort5+3 @84, 3, 6),
 (Block sort5+5 @86, 1, 6),
 (Block sort5skip0+2 @95, 1, 6),
 (Block sort5skip1+3 @105, 1, 6),
 (Block sort5skip2+1 @113, 3, 6),
 (Block sort5skip3+1 @123, 3, 6),
 (Block sort5skip7+1 @161, 4, 8),
 (Block sort5+1 @82, 4, 8),
 (Block sort5skip8 @169, 4, 8),
 (Block zeroloop+2 @38, 2, 8),
 (Block sort5skip1 @101, 4, 8),
 (Block sort5skip7 @159, 4, 8),
 (Block sort5skip6 @149, 4, 8),
 (Block sort5skip1+1 @103, 4, 8),
 (Block sort5skip2 @111, 4, 8),
 (Block sort5 @80, 4, 8),
 (Block sort5skip4 @131, 3, 9),
 (Block sort5skip0 @92, 3, 9),
 (Block simplywritesecond+1 @177, 3, 9),
 (Block start @13, 5, 10),
 (Block simplywritesecond @175, 5, 10),
 (Block writeboth+6 @51, 2, 10),
 (Block firstsort @70, 1, 10),
 (Block readloop+4 @34, 11, 11),
 (Block sort5skip5 @140, 4, 12),
 (Block start21wasok+2 @18, 4, 12),
 (Block zeroloop @35, 4, 12),
 (Block sort5skip2+3 @115, 2, 12),
 (Block sort5skip3+3 @125, 2, 12),
 (Block @0, 1, 13),
 (Block simplywritesecondloop+2 @183, 8, 16),
 (Block start21wasok @15, 6, 18),
 (Block merge @48, 7, 21),
 (Block start21wasok+5 @21, 3, 24),
 (Block output15 @64, 5, 25),
 (Block readloop @29, 14, 28),
 (Block simplywritesecondloop @180, 11, 33),
 (Block secondsort @189, 3, 33),
 (Block readloop+1 @31, 12, 36)]
547
```